### PR TITLE
requirements_for_module requires CPAN::Meta::Requirements 2.120920

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,10 @@
 Revision history for Dist-Zilla-Plugin-Test-ReportPrereqs
 
 {{$NEXT}}
+  [Fixed]
+
+  - no longer attempting to use a version of CPAN::Meta::Requirements that is
+    too old [Karen Etheridge]
 
 0.007     2013-10-12 13:50:23 America/New_York
 

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -173,12 +173,13 @@ if ( -f $source && eval "require $cpan_meta" ) { ## no critic
     # If verifying, merge 'requires' only for major phases
     if ( INSERT_VERIFY_PREREQS_CONFIG ) {
       $prereqs = $meta->effective_prereqs; # get the object, not the hash
-      eval "require $cpan_meta_req"; ## no critic
-      $all_requires = CPAN::Meta::Requirements->new;
-      for my $phase ( qw/configure build test runtime/ ) {
-        $all_requires->add_requirements(
-          $prereqs->requirements_for($phase, 'requires')
-        );
+      if (eval "require $cpan_meta_req; 1") { ## no critic
+        $all_requires = $cpan_meta_req->new;
+        for my $phase ( qw/configure build test runtime/ ) {
+          $all_requires->add_requirements(
+            $prereqs->requirements_for($phase, 'requires')
+          );
+        }
       }
     }
   }
@@ -198,7 +199,7 @@ for my $mod ( @modules ) {
     $ver = "undef" unless defined $ver; # Newer MM should do this anyway
     push @reports, [$ver, $mod];
 
-    if ( INSERT_VERIFY_PREREQS_CONFIG && $all_requires ) {
+    if ( INSERT_VERIFY_PREREQS_CONFIG && $all_requires && eval "$cpan_meta_req->VERSION(2.120920); 1") {
       my $req = $all_requires->requirements_for_module($mod);
       if ( defined $req && length $req ) {
         if ( ! eval { version->parse($ver) } ) {


### PR DESCRIPTION
As seen in http://cpantesters.org/cpan/report/f5684454-3418-11e3-89fd-d34c40c32a75
-- need to gracefully handle CPAN::Meta::Requirements not existing, or not being at a high enough version to do the verification step.
