### PR TITLE
inject CPAN::Meta* as test recommends

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Dist-Zilla-Plugin-Test-ReportPrereqs
 
 {{$NEXT}}
 
+  [Changed]
+
+  - now injecting test-recommends prereqs to enable prereq verification
+    (Karen Etheridge)
+
 0.008     2013-10-13 15:33:03 America/New_York
 
   [Fixed]

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -12,7 +12,8 @@ use File::Spec::Functions;
 
 use Moose;
 extends 'Dist::Zilla::Plugin::InlineFiles';
-with 'Dist::Zilla::Role::AfterBuild';
+with 'Dist::Zilla::Role::AfterBuild',
+    'Dist::Zilla::Role::PrereqSource';
 
 sub mvp_multivalue_args {
     return qw( include exclude );
@@ -33,6 +34,19 @@ has verify_prereqs => (
     isa     => 'Bool',
     default => 1,
 );
+
+sub register_prereqs {
+    my $self    = shift;
+
+    $self->zilla->register_prereqs(
+      {
+        phase => 'test',
+        type  => 'recommends',
+      },
+      'CPAN::Meta' => '0',
+      'CPAN::Meta::Requirements' => 0,
+    );
+}
 
 sub after_build {
     my ( $self, $opt ) = @_;


### PR DESCRIPTION
If things aren't fulfilling prereqs properly they wouldn't fulfill this either, but it's always nice to be explicit about what is being used.
