### PR TITLE
missing develop prereqs were not ever being checked

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Dist-Zilla-Plugin-Test-ReportPrereqs
 
 {{$NEXT}}
 
+  [Fixed]
+
+  - now also verifying develop prereqs, when AUTHOR_TESTING is set
+    (Karen Etheridge)
+
 0.010     2013-10-16 17:02:34 America/New_York
 
   [Fixed]

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -189,7 +189,7 @@ if ( -f $source && eval "require $cpan_meta" ) { ## no critic
       $prereqs = $meta->effective_prereqs; # get the object, not the hash
       if (eval "require $cpan_meta_req; 1") { ## no critic
         $all_requires = $cpan_meta_req->new;
-        for my $phase ( qw/configure build test runtime/ ) {
+        for my $phase ( qw/configure build test runtime develop/ ) {
           $all_requires->add_requirements(
             $prereqs->requirements_for($phase, 'requires')
           );


### PR DESCRIPTION
..Found just after discovering that `; authordep Foo` dependencies aren't being verified at dzil build time, either
