### PR TITLE
Move to InstallTool phase.

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -1,9 +1,7 @@
 requires "Dist::Zilla" => "4";
 requires "Dist::Zilla::Plugin::InlineFiles" => "0";
-requires "Dist::Zilla::Role::AfterBuild" => "0";
+requires "Dist::Zilla::Role::InstallTool" => "0";
 requires "Dist::Zilla::Role::PrereqSource" => "0";
-requires "File::Slurp" => "0";
-requires "File::Spec::Functions" => "0";
 requires "Moose" => "0";
 requires "perl" => "5.006";
 requires "strict" => "0";
@@ -14,6 +12,7 @@ on 'test' => sub {
   requires "Cwd" => "0";
   requires "Dist::Zilla::Tester" => "0";
   requires "ExtUtils::MakeMaker" => "0";
+  requires "File::Spec::Functions" => "0";
   requires "File::pushd" => "0";
   requires "List::Util" => "0";
   requires "Path::Class" => "0";
@@ -31,7 +30,7 @@ on 'configure' => sub {
 };
 
 on 'develop' => sub {
-  requires "Dist::Zilla" => "5.008";
+  requires "Dist::Zilla" => "5.011";
   requires "Dist::Zilla::PluginBundle::DAGOLDEN" => "0.053";
   requires "File::Spec" => "0";
   requires "File::Temp" => "0";


### PR DESCRIPTION
This means we can munge the file in memory using DZil toolchain,
  absolving the need for slurp and friends.

Also, munging becomes visible to things that run afterwards, like
  CommitBuild, where its preferable to commit the test, not the test
  template.

As it was, the functionality relied on the fact git writes-out to the
  built-in dir prior to invoking tar on that directory, which would become
  broken if dzil had ever decided to change that.

This should resolve https://github.com/dagolden/Dist-Zilla-Plugin-Test-ReportPrereqs/issues/11 

In action: 

https://github.com/kentfredric/Dist-Zilla-PluginBundle-Author-KENTNL/commit/bbd336c0eb7016d8032ce381a1b42baf725809a5#diff-57a714aa1ef1dbe051e98656c8fbd5b0
