### PR TITLE
avoid meta validation issues by never creating a META.yml

### DIFF
--- a/corpus/DZ/dist.ini
+++ b/corpus/DZ/dist.ini
@@ -6,14 +6,8 @@ abstract = Test Library
 copyright_holder = foobar
 copyright_year   = 2009
 
-[@Filter]
-bundle = @FakeClassic
-remove = ExtraTests
-remove = PodVersion
-remove = PodSyntaxTests
-remove = PodCoverageTests
-remove = ConfirmRelease
-remove = UploadToCPAN
+[GatherDir]
+[MakeMaker]
 
 [AutoPrereqs]
 


### PR DESCRIPTION


When CPAN::Meta and Dist::Zilla versions are out of sync, we can get errors like this:

```
t/report.t .. 1/? [@Filter/MetaYAML] Invalid META structure.  Errors found:
[@Filter/MetaYAML] Expected a list structure (license) [Validation: 2] at /Volumes/amaretto/Users/ether/.perlbrew/libs/20.0@std/lib/perl5/darwin-2level/Moose/Meta/Method/Delegation.pm line 110.
```

...which aren't your problem. Avoid all this by only pulling in the minimum necessary plugins in tests.
