### PR TITLE
resolve error when loading dd file on 5.25.11+

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Dist-Zilla-Plugin-Test-ReportPrereqs
 
 {{$NEXT}}
 
+  [Fixed]
+
+  - prereq data file is properly sourced in newer perls, when . is no longer
+    in @INC
+
 0.025     2016-06-09 22:08:35-04:00 America/New_York
 
   [Fixed]

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -120,7 +120,7 @@ sub _munge_test {
     return $guts;
 }
 
-sub _dump_filename { 't/00-report-prereqs.dd' }
+sub _dump_filename { './t/00-report-prereqs.dd' }
 
 sub _format_list {
     return join( "\n", map { "  $_" } @_ );


### PR DESCRIPTION
. is no longer in @INC, so relative paths must be prefaced with '.' when
used with require or do directives.