### PR TITLE
fix manifest filename for dd file

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,11 @@ Revision history for Dist-Zilla-Plugin-Test-ReportPrereqs
 
 {{$NEXT}}
 
+  [Fixed]
+
+  - fixed error in 0.026 that would cause t/00-report-prereqs.dd to be pruned
+    by [PruneCruft]
+
 0.026     2017-05-05 22:30:00-04:00 America/New_York
 
   [Fixed]

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -102,7 +102,7 @@ sub gather_files {
 sub _munge_test {
     my ( $self, $guts ) = @_;
     $guts =~ s{INSERT_VERSION_HERE}{$self->VERSION || '<self>'}e;
-    $guts =~ s{INSERT_DD_FILENAME_HERE}{$self->_dump_filename}e;
+    $guts =~ s{INSERT_DD_FILENAME_HERE}{'./' . $self->_dump_filename}e;
     $guts =~ s{INSERT_INCLUDED_MODULES_HERE}{_format_list($self->included_modules)}e;
     $guts =~ s{INSERT_EXCLUDED_MODULES_HERE}{_format_list($self->excluded_modules)}e;
     $guts =~ s{INSERT_VERIFY_PREREQS_CONFIG}{$self->verify_prereqs ? 1 : 0}e;
@@ -120,7 +120,7 @@ sub _munge_test {
     return $guts;
 }
 
-sub _dump_filename { './t/00-report-prereqs.dd' }
+sub _dump_filename { 't/00-report-prereqs.dd' }
 
 sub _format_list {
     return join( "\n", map { "  $_" } @_ );


### PR DESCRIPTION
The file was being added as './00-report-prereqs.dd' and entering the
MANIFEST with that name, which while not strictly wrong on its own,
would trigger [PruneCruft]'s regex and cause the file to be removed.

(I don't use `[PruneCruft]` in my own bundle so I didn't notice this while testing, but it became immediately apparent as soon as I built someone else's distribution after upgrading the plugin! doh.)