### PR TITLE
Add a test name in the call to pass() in the generated file

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,13 @@ Revision history for Dist-Zilla-Plugin-Test-ReportPrereqs
 
 {{$NEXT}}
 
+  [Changed]
+
+  - Passed a test name in the call to `pass()` in the generated test
+    file. This makes the output nicer when the test is run via
+    Test2::Harness. (Dave Rolsky)
+
+
 0.027     2017-05-07 22:59:43-04:00 America/New_York
 
   [Fixed]

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -405,6 +405,6 @@ if ( @dep_errors ) {
     );
 }
 
-pass;
+pass('Reported prereqs');
 
 # vim: ts=4 sts=4 sw=4 et:


### PR DESCRIPTION
Unnamed tests look okay in TAP, but if you use Test2::Formatter or generate
JUnit from your tests it ends up being called out in various ways as an
unnamed test case.