### PR TITLE
do show perl prereq

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use 5.006;
+use 5.020;
 
 use ExtUtils::MakeMaker 6.17;
 
@@ -13,7 +13,7 @@ my %WriteMakefileArgs = (
   },
   "DISTNAME" => "Dist-Zilla-Plugin-Test-ReportPrereqs",
   "LICENSE" => "apache",
-  "MIN_PERL_VERSION" => "5.006",
+  "MIN_PERL_VERSION" => "5.020",
   "NAME" => "Dist::Zilla::Plugin::Test::ReportPrereqs",
   "PREREQ_PM" => {
     "Data::Dumper" => 0,
@@ -26,7 +26,6 @@ my %WriteMakefileArgs = (
     "Moose" => 0,
     "Moose::Util::TypeConstraints" => 0,
     "Sub::Exporter::ForMethods" => 0,
-    "strict" => 0,
     "warnings" => 0
   },
   "TEST_REQUIRES" => {
@@ -38,7 +37,8 @@ my %WriteMakefileArgs = (
     "File::pushd" => 0,
     "Path::Tiny" => 0,
     "Test::Harness" => 0,
-    "Test::More" => "0.96"
+    "Test::More" => "0.96",
+    "strict" => 0
   },
   "VERSION" => "0.029",
   "test" => {

--- a/dist.ini
+++ b/dist.ini
@@ -6,3 +6,4 @@ copyright_year   = 2012
 
 [@DAGOLDEN]
 :version = 0.072
+no_minimum_perl = 1

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -325,19 +325,23 @@ for my $phase ( qw(configure build test runtime develop other) ) {
         my @reports = [qw/Module Want Have/];
 
         for my $mod ( sort keys %{ $req_hash->{$phase}{$type} } ) {
-            next if $mod eq 'perl';
             next if grep { $_ eq $mod } @exclude;
-
-            my $file = $mod;
-            $file =~ s{::}{/}g;
-            $file .= ".pm";
-            my ($prefix) = grep { -e File::Spec->catfile($_, $file) } @INC;
 
             my $want = $req_hash->{$phase}{$type}{$mod};
             $want = "undef" unless defined $want;
             $want = "any" if !$want && $want == 0;
 
+            if ($mod eq 'perl') {
+                push @reports, ['perl', $want, $]];
+                next;
+            }
+
             my $req_string = $want eq 'any' ? 'any version required' : "version '$want' required";
+
+            my $file = $mod;
+            $file =~ s{::}{/}g;
+            $file .= ".pm";
+            my ($prefix) = grep { -e File::Spec->catfile($_, $file) } @INC;
 
             if ($prefix) {
                 my $have = VERSION_EXTRACTION;

--- a/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
+++ b/lib/Dist/Zilla/Plugin/Test/ReportPrereqs.pm
@@ -1,5 +1,4 @@
-use 5.006;
-use strict;
+use 5.020;
 use warnings;
 
 package Dist::Zilla::Plugin::Test::ReportPrereqs;


### PR DESCRIPTION
Right now, this plugin won't show the perl version requested or present.  Some forms of testing don't readily give up the perl version shown (like GitHub actions) and rather than change methods, it seems reasonable to show the perl version in this report, even if it isn't a module.